### PR TITLE
Fix for animation only running on initial mount.

### DIFF
--- a/src/SkeletonContent.tsx
+++ b/src/SkeletonContent.tsx
@@ -135,8 +135,10 @@ export default class SkeletonContent extends React.Component<
     }
   }
 
-  componentDidMount() {
-    this.playAnimation();
+  componentDidUpdate() {
+    if (this.state.isLoading) {
+      this.playAnimation();
+    }
   }
 
   playAnimation = () => {

--- a/src/SkeletonContent.tsx
+++ b/src/SkeletonContent.tsx
@@ -139,6 +139,7 @@ export default class SkeletonContent extends React.Component<
     if (this.state.isLoading) {
       this.playAnimation();
     }
+    else {}
   }
 
   playAnimation = () => {


### PR DESCRIPTION
Hey,

I've been using this package in an app and i'm swapping back to the placeholder when the user refreshes the list. I've noticed the animation doesn't fire if you toggle isLoading so I've implemented a fix so it will always re-run when the state changes.

Hope this is useful and i can continue using this branch or i'll just maintain my own fork.

Cheers.