### PR TITLE
Add support for more complex layouts with a children option

### DIFF
--- a/src/SkeletonContent.tsx
+++ b/src/SkeletonContent.tsx
@@ -234,7 +234,7 @@ export default class SkeletonContent extends React.Component<
     <View key={layoutStyle.key || key} style={layoutStyle}>
         {children}
     </View>
-);
+  );
 
   getStaticBone = (layoutStyle: CustomViewStyle, key: number): JSX.Element => (
     <Animated.View key={layoutStyle.key || key} style={this.getBoneStyles(layoutStyle)} />
@@ -272,11 +272,12 @@ export default class SkeletonContent extends React.Component<
       }
       return iterator.map((_, i) => {
         if (layout[i].children && layout[i].children.length > 0) {
+          const containerPrefix = layout[i].key || `bone_container_${i}`;
           return this.getBoneContainer(
             layout[i],
-            this.getBones(layout[i].children, [], `bone_container_${i}`),
+            this.getBones(layout[i].children, [], containerPrefix),
             `${prefix}_${i}`
-          )
+          );
         } else {
           if (
             this.props.animationType === "pulse" ||

--- a/src/SkeletonContent.tsx
+++ b/src/SkeletonContent.tsx
@@ -234,13 +234,13 @@ export default class SkeletonContent extends React.Component<
     <View key={layoutStyle.key || key} style={layoutStyle}>
         {children}
     </View>
-  );
+);
 
-  getStaticBone = (layoutStyle: CustomViewStyle, key: number): JSX.Element => (
+  getStaticBone = (layoutStyle: CustomViewStyle, key: string | number): JSX.Element => (
     <Animated.View key={layoutStyle.key || key} style={this.getBoneStyles(layoutStyle)} />
   );
 
-  getShiverBone = (layoutStyle: CustomViewStyle, key: number): JSX.Element => (
+  getShiverBone = (layoutStyle: CustomViewStyle, key: string | number): JSX.Element => (
     <View key={layoutStyle.key || key} style={this.getBoneStyles(layoutStyle)}>
       <Animated.View
         style={[
@@ -276,16 +276,16 @@ export default class SkeletonContent extends React.Component<
           return this.getBoneContainer(
             layout[i],
             this.getBones(layout[i].children, [], containerPrefix),
-            `${prefix}_${i}`
-          );
+            containerPrefix
+          )
         } else {
           if (
             this.props.animationType === "pulse" ||
             this.props.animationType === "none"
           ) {
-            return this.getStaticBone(layout[i], i);
+            return this.getStaticBone(layout[i], prefix ? `${prefix}_${i}` : i);
           } else {
-            return this.getShiverBone(layout[i], i);
+            return this.getShiverBone(layout[i], prefix ? `${prefix}_${i}` : i);
           }
         }
       });

--- a/src/SkeletonContent.tsx
+++ b/src/SkeletonContent.tsx
@@ -273,11 +273,7 @@ export default class SkeletonContent extends React.Component<
       return iterator.map((_, i) => {
         if (layout[i].children && layout[i].children.length > 0) {
           const containerPrefix = layout[i].key || `bone_container_${i}`;
-          return this.getBoneContainer(
-            layout[i],
-            this.getBones(layout[i].children, [], containerPrefix),
-            containerPrefix
-          )
+          return this.getBoneContainer(layout[i], this.getBones(layout[i].children, [], containerPrefix), containerPrefix);
         } else {
           if (
             this.props.animationType === "pulse" ||

--- a/src/SkeletonContent.tsx
+++ b/src/SkeletonContent.tsx
@@ -229,6 +229,12 @@ export default class SkeletonContent extends React.Component<
     return outputRange;
   };
 
+  getBoneContainer = (layoutStyle: CustomViewStyle, children: JSX.Element[], key: string) => (
+    <View key={layoutStyle.key || key} style={layoutStyle}>
+        {children}
+    </View>
+);
+
   getStaticBone = (layoutStyle: CustomViewStyle, key: number): JSX.Element => (
     <Animated.View key={layoutStyle.key || key} style={this.getBoneStyles(layoutStyle)} />
   );
@@ -257,20 +263,28 @@ export default class SkeletonContent extends React.Component<
     </View>
   );
 
-  getBones = (layout: CustomViewStyle[], children: any): JSX.Element[] => {
+  getBones = (layout: CustomViewStyle[], children: any, prefix = ''): JSX.Element[] => {
     if (layout.length > 0) {
       const iterator: number[] = new Array(layout.length);
       for (let i = 0; i < layout.length; i++) {
         iterator[i] = 0;
       }
       return iterator.map((_, i) => {
-        if (
-          this.props.animationType === "pulse" ||
-          this.props.animationType === "none"
-        ) {
-          return this.getStaticBone(layout[i], i);
+        if (layout[i].children && layout[i].children.length > 0) {
+          return this.getBoneContainer(
+            layout[i],
+            this.getBones(layout[i].children, [], `bone_container_${i}`),
+            `${prefix}_${i}`
+          )
         } else {
-          return this.getShiverBone(layout[i], i);
+          if (
+            this.props.animationType === "pulse" ||
+            this.props.animationType === "none"
+          ) {
+            return this.getStaticBone(layout[i], i);
+          } else {
+            return this.getShiverBone(layout[i], i);
+          }
         }
       });
     } else {


### PR DESCRIPTION
Hey, so i've been implementing some more complicated loaders and ran into an issue when trying to do horizontal loaders or implementing more complex layouts in a single loader rather than using multiple elements.

I've added a way to do this using a `children` key on the layout objects, here is an example that as far as i can tell isn't possible without this:

**Layout:**
![image](https://user-images.githubusercontent.com/5281898/75052141-62c0fe00-54cf-11ea-92b1-e695d41a5fb0.png)

**Code:**
```
[
    {
        flexDirection: 'row',
        key: 'example_key',
        children: [
            {
                marginLeft: 20,
                children: [
                    {
                        key: 'image',
                        width: 130,
                        height: 150,
                        borderRadius: 24,
                    },
                    {
                        key: 'body_1',
                        width: 130 / 1.5,
                        height: 18,
                        marginBottom: 6,
                        marginTop: 10,
                    },
                    {
                        key: 'body_2',
                        width: 130 / 3,
                        height: 13,
                        marginBottom: 6,
                    },
                ],
            },
            ...
        ],
    },
]
```

If a layout has a children key then it just renders a [`<View>`](https://github.com/hparton/react-native-skeleton-content-nonexpo/blob/09a81efe26f9807ae468acebe9a198e0364eb7cf/src/SkeletonContent.tsx#L233) element and then recursively calls `getBones` so we end up with multiple loader layouts in one `<SkeletonLoader>` and prefixes everything inside that container with the provided key or a default so we don't get any key duplicates.