### PR TITLE
perf: set `useNativeDriver` to true on animations

### DIFF
--- a/src/SkeletonContent.tsx
+++ b/src/SkeletonContent.tsx
@@ -149,12 +149,14 @@ export default class SkeletonContent extends React.Component<
             toValue: 1,
             duration: this.props.duration! / 2,
             easing: this.props.easing,
-            delay: this.props.duration
+            delay: this.props.duration,
+            useNativeDriver: true,
           }),
           Animated.timing(this.animationPulse, {
             toValue: 0,
             easing: this.props.easing,
-            duration: this.props.duration! / 2
+            duration: this.props.duration! / 2,
+            useNativeDriver: true,
           })
         ])
       ).start();
@@ -163,7 +165,8 @@ export default class SkeletonContent extends React.Component<
         Animated.timing(this.animationShiver, {
           toValue: 1,
           duration: this.props.duration,
-          easing: this.props.easing
+          easing: this.props.easing,
+          useNativeDriver:true
         })
       ).start();
     }


### PR DESCRIPTION
This serves master a performance improvement as well as a fix for the numerous warnings that come up when using Animations without passing the `useNativeDriver` mandatory property.

Also, the numerous warning messages were blocking the JS thread, making the application very slow when developing.

@see https://github.com/facebook/react-native/issues/28558 concerning useNativeDriver