### PR TITLE
Fix the problem of not playing animation for the first time

### DIFF
--- a/src/SkeletonContent.tsx
+++ b/src/SkeletonContent.tsx
@@ -141,6 +141,12 @@ export default class SkeletonContent extends React.Component<
     }
   }
 
+  componentDidUpdate() {
+    if (this.state.isLoading) {
+      this.playAnimation();
+    }
+  }
+
   playAnimation = () => {
     if (this.props.animationType === "pulse") {
       Animated.loop(

--- a/src/SkeletonContent.tsx
+++ b/src/SkeletonContent.tsx
@@ -135,7 +135,7 @@ export default class SkeletonContent extends React.Component<
     }
   }
 
-  componentDidUpdate() {
+  componentDidMount() {
     if (this.state.isLoading) {
       this.playAnimation();
     }


### PR DESCRIPTION
The `componentDidMount` will call back after the first render.
The  `componentDidUpdate` will call back after the props or status change.
setting loading status is true when the init component. The animation will not be started.