### PR TITLE
Add support for percentages in shiver bones

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -37,6 +37,7 @@ export interface ISkeletonContentProps {
 export interface IState {
   isLoading: boolean;
   layout: CustomViewStyle[];
+  containerLayout: { width: number; height: number };
 }
 
 export interface IDirection {

--- a/src/SkeletonContent.tsx
+++ b/src/SkeletonContent.tsx
@@ -40,7 +40,8 @@ const getInitialState = ({
   layout
 }: ISkeletonContentProps): IState => ({
   isLoading,
-  layout: layout!
+  layout: layout!,
+  containerLayout: { width: 0, height: 0 }
 });
 
 const getDefaultProps = (): ISkeletonContentProps => ({
@@ -208,8 +209,14 @@ export default class SkeletonContent extends React.Component<
 
   getPositionRange = (boneLayout: CustomViewStyle): number[] => {
     const outputRange: number[] = [];
-    const boneWidth = boneLayout.width || 0;
-    const boneHeight = boneLayout.height || 0;
+    const boneWidth =
+      typeof boneLayout.width === "string"
+        ? this.state.containerLayout.width
+        : boneLayout.width || 0;
+    const boneHeight =
+      typeof boneLayout.width === "string"
+        ? this.state.containerLayout.height
+        : boneLayout.height || 0;
 
     if (
       this.props.animationDirection === "horizontalRight" ||
@@ -243,7 +250,7 @@ export default class SkeletonContent extends React.Component<
   );
 
   getShiverBone = (layoutStyle: CustomViewStyle, key: string | number): JSX.Element => (
-    <View key={layoutStyle.key || key} style={this.getBoneStyles(layoutStyle)}>
+    <View key={layoutStyle.key || key} style={[ this.getBoneStyles(layoutStyle), { overflow: 'hidden' } ]}>
       <Animated.View
         style={[
           styles.absoluteGradient,
@@ -314,7 +321,12 @@ export default class SkeletonContent extends React.Component<
     const bones = this.getBones(layout, children);
 
     return (
-      <View style={this.props.containerStyle}>
+      <View
+        style={this.props.containerStyle}
+        onLayout={event =>
+          this.setState({ containerLayout: event.nativeEvent.layout })
+        }
+      >
         {this.renderLayout(isLoading, bones, children)}
       </View>
     );

--- a/src/SkeletonContent.tsx
+++ b/src/SkeletonContent.tsx
@@ -150,13 +150,13 @@ export default class SkeletonContent extends React.Component<
             duration: this.props.duration! / 2,
             easing: this.props.easing,
             delay: this.props.duration,
-            useNativeDriver: true,
+            useNativeDriver: false,
           }),
           Animated.timing(this.animationPulse, {
             toValue: 0,
             easing: this.props.easing,
             duration: this.props.duration! / 2,
-            useNativeDriver: true,
+            useNativeDriver: false,
           })
         ])
       ).start();


### PR DESCRIPTION
This merge Request contains the following commits which have been compiled and tested locally in my builds.

1. fix: fix `Invariant Violation: ..."translateX": "<<NAN>>"... is not usable as native method argument`

This comes in as a `fix and feature`, `now permitting the use of percentages in shiver bones`. Percentages initially work with 'none', 'pulse' animationTypes.
Commit addresses this issue https://github.com/alexZajac/react-native-skeleton-content/issues/6

2. fix: fix `Style property 'backgroundColor' not supported by native animated module`

This occurs when using a 'pulse' animation type, since we are using the native driver to animate the backgroundColor.