### PR TITLE
perf: add `PureSkeletonContent` component to improve performance by reducing re-rendering of component

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,46 @@ export default function Placeholder () {
 
 **Note**: The Easing type function is the one provided by [react-native-reanimated](https://github.com/software-mansion/react-native-reanimated), so if you want to change the default you will have to install it as a dependency.
 
+## PureSkeletonContent
+If you are really concerned about performance, or you don't want your components mounting being runned while
+`isLoading` **is false**, then you may need to consider using `PureSkeletonContent`.
+
+#### Point to note 
+All props passed to PureSkeletonContent should be a **constant** prop, **memoize** it if it will change sometime.
+Otherwise, you should consider using the good old `SkeletonContent`.
+
+
+```typescript jsx
+import { FunctionComponent } from 'react';
+import { Text, TextStyle, StyleSheet } from 'react-native';
+import { PureSkeletonContent } from 'react-native-skeleton-content-nonexpo'; 
+
+const Greetings: FunctionComponent<{ name: string }> = ({ name }) => 
+  (<Text>Hello {name}</Text>);
+
+const GreetingsSC = [{ height: 40, width: 200, paddingVertical: 2 }];
+
+const SomeComponent: FunctionComponent<{name: string}> = ({ name }) => {
+  const [loading, setLoading] = useState(true);
+
+  return (
+    <PureSkeletonContent 
+      isLoading={isLoading}
+      layout={GreetingsSC}
+      component={Greetings} 
+      componentProps={{ name }} 
+      containerStyle={styles.container} // notice we using styles from styleSheet
+    />
+  )
+}
+
+const styles = StyleSheet({
+  container: {
+    flex: 1, width: 300
+  }
+})
+```
+
 ### Examples
 
 See the playground section to experiment :

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1,4 +1,5 @@
 import { StyleProp, ViewStyle } from 'react-native';
+import { ComponentType } from 'react';
 import Animated, { Easing } from 'react-native-reanimated';
 
 type _animationType = 'none' | 'shiver' | 'pulse' | undefined;
@@ -30,6 +31,15 @@ export interface ISkeletonContentProps {
   easing?: Animated.EasingFunction;
   children?: any;
 }
+
+export interface IPureSkeletonContentPropsFields<T = any> {
+  component: ComponentType<T>;
+  componentProps?: T;
+}
+
+export interface IPureSkeletonContentProps<T>
+  extends IPureSkeletonContentPropsFields<T>,
+    Omit<ISkeletonContentProps, 'children'> {}
 
 export interface IDirection {
   x: number;

--- a/src/PureSkeletonContent.tsx
+++ b/src/PureSkeletonContent.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { IPureSkeletonContentProps } from './Constants';
+import SkeletonContent from './SkeletonContent';
+
+const didChange = <T extends object>(
+  prev: any,
+  next: any,
+  removeKey?: keyof IPureSkeletonContentProps<T>
+) => {
+  const prevKeys = Object.keys(prev);
+  const nextKeys = Object.keys(next);
+
+  if (prevKeys.length !== nextKeys.length) {
+    return true;
+  }
+
+  const keys = new Set([...prevKeys, ...nextKeys]);
+
+  if (removeKey) {
+    keys.delete(removeKey);
+  }
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const key of keys) {
+    if (!Object.is(prev[key], next[key])) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const PureSkeletonContent = <T,>(props: IPureSkeletonContentProps<T>) => {
+  return <SkeletonContent {...props} />;
+};
+
+export default React.memo(PureSkeletonContent, (prev, next) => {
+  if (didChange(prev, next, 'componentProps')) {
+    return false;
+  }
+
+  if (Object.is(prev.componentProps, next.componentProps)) {
+    return true;
+  }
+
+  if (
+    typeof prev.componentProps === 'object' &&
+    typeof next.componentProps === 'object'
+  ) {
+    return !didChange(prev.componentProps, next.componentProps);
+  }
+
+  return false;
+}) as typeof PureSkeletonContent;

--- a/src/SkeletonContent.tsx
+++ b/src/SkeletonContent.tsx
@@ -14,7 +14,8 @@ import {
   DEFAULT_HIGHLIGHT_COLOR,
   DEFAULT_LOADING,
   ISkeletonContentProps,
-  IDirection
+  IDirection,
+  IPureSkeletonContentPropsFields
 } from './Constants';
 
 const { useCode, set, cond, eq } = Animated;
@@ -47,7 +48,8 @@ const useLayout = () => {
   return [size, onLayout];
 };
 
-const SkeletonContent: React.FunctionComponent<ISkeletonContentProps> = ({
+const SkeletonContent: React.FunctionComponent<ISkeletonContentProps &
+  Partial<IPureSkeletonContentPropsFields>> = ({
   containerStyle = styles.container,
   easing = DEFAULT_EASING,
   duration = DEFAULT_DURATION,
@@ -57,7 +59,9 @@ const SkeletonContent: React.FunctionComponent<ISkeletonContentProps> = ({
   isLoading = DEFAULT_LOADING,
   boneColor = DEFAULT_BONE_COLOR,
   highlightColor = DEFAULT_HIGHLIGHT_COLOR,
-  children
+  children,
+  component: Component,
+  componentProps
 }) => {
   const animationValue = useValue(0);
   const loadingValue = useValue(isLoading ? 1 : 0);
@@ -383,11 +387,14 @@ const SkeletonContent: React.FunctionComponent<ISkeletonContentProps> = ({
     });
   };
 
+  const getComponent = () =>
+    Component ? <Component {...componentProps} /> : children;
+
   return (
     <View style={containerStyle} onLayout={onLayout}>
-      {isLoading ? getBones(layout!, children) : children}
+      {isLoading ? getBones(layout!, children) : getComponent()}
     </View>
   );
 };
 
-export default React.memo(SkeletonContent);
+export default SkeletonContent;

--- a/src/__tests__/PureSkeletonContent.test.tsx
+++ b/src/__tests__/PureSkeletonContent.test.tsx
@@ -1,0 +1,235 @@
+import { Text, TextStyle } from 'react-native';
+import React, { FunctionComponent, useEffect, useRef } from 'react';
+import Animated from 'react-native-reanimated';
+
+import LinearGradient from 'react-native-linear-gradient';
+import { create } from 'react-test-renderer';
+import PureSkeletonContent from '../PureSkeletonContent';
+import {
+  ISkeletonContentProps,
+  DEFAULT_BONE_COLOR,
+  DEFAULT_BORDER_RADIUS
+} from '../Constants';
+
+const staticStyles = {
+  borderRadius: DEFAULT_BORDER_RADIUS,
+  overflow: 'hidden',
+  backgroundColor: DEFAULT_BONE_COLOR
+};
+
+const Greetings: FunctionComponent<{ name: string; style?: TextStyle }> = ({
+  name,
+  style
+}) => {
+  return <Text style={style}>Hello {name}</Text>;
+};
+
+const RenderCounter: FunctionComponent<{ count?: number }> = ({ count }) => {
+  const localCount = useRef(0);
+
+  useEffect(() => {
+    localCount.current += 1;
+  });
+
+  return (
+    <Text>
+      Local: {localCount.current} Props: {count}
+    </Text>
+  );
+};
+
+const RenderFromTop: FunctionComponent<{
+  isLoading?: boolean;
+  count?: number;
+  otherField?: number;
+}> = ({ isLoading, count }) => {
+  return (
+    <PureSkeletonContent
+      isLoading={!!isLoading}
+      component={RenderCounter}
+      componentProps={{ count }}
+    />
+  );
+};
+
+describe('PureSkeletonContent test suite', () => {
+  it('should render empty alone', () => {
+    const tree = create(
+      <PureSkeletonContent
+        isLoading={false}
+        component={Greetings}
+        componentProps={{ name: 'World' }}
+      />
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should pass down props to component', () => {
+    const instance = create(
+      <PureSkeletonContent
+        isLoading={false}
+        component={Greetings}
+        componentProps={{ name: 'mernxl' }}
+      />
+    );
+
+    expect(instance.root.findAllByType(Greetings)[0].props.name).toEqual(
+      'mernxl'
+    );
+  });
+
+  it('should not render component when isLoading is true', () => {
+    const instance = create(
+      <PureSkeletonContent
+        isLoading
+        component={Greetings}
+        componentProps={{ name: 'mernxl' }}
+      />
+    );
+
+    expect(instance.root.findAllByType(Greetings).length).toBe(0);
+  });
+
+  it('should not re-render PureSkeleton on top component and same props re-render', () => {
+    // first render local = 0
+    const instance = create(<RenderFromTop count={0} />);
+    expect(instance.toJSON()).toMatchSnapshot();
+
+    // update props, local should be 1
+    instance.update(<RenderFromTop count={1} />);
+    expect(instance.toJSON()).toMatchSnapshot();
+
+    // cause FromTop to re render, local stays 1
+    instance.update(<RenderFromTop otherField={2} count={1} />);
+    expect(instance.toJSON()).toMatchSnapshot();
+
+    // update props local goes to 2, since count now undefined
+    instance.update(<RenderFromTop />);
+
+    expect(instance.toJSON()).toMatchSnapshot();
+  });
+
+  it('should have the correct layout when loading', () => {
+    const layout = [
+      {
+        width: 240,
+        height: 100,
+        marginBottom: 10
+      },
+      {
+        width: 180,
+        height: 40,
+        borderRadius: 20,
+        backgroundColor: 'grey'
+      }
+    ];
+    const props: ISkeletonContentProps = {
+      layout,
+      isLoading: true,
+      animationType: 'none'
+    };
+    const instance = create(
+      <PureSkeletonContent
+        {...props}
+        component={Greetings}
+        componentProps={{ name: 'mernxl' }}
+      />
+    );
+
+    const component = instance.root;
+    const bones = component.findAllByType(Animated.View);
+
+    // two bones and parent component
+    expect(bones.length).toEqual(layout.length + 1);
+    expect(bones[0].props.style).toEqual({
+      alignItems: 'center',
+      flex: 1,
+      justifyContent: 'center'
+    });
+    // default props that are not set
+    expect(bones[1].props.style).toEqual([{ ...layout[0], ...staticStyles }]);
+    expect(bones[2].props.style).toEqual([
+      { overflow: 'hidden', ...layout[1] }
+    ]);
+    expect(instance.toJSON()).toMatchSnapshot();
+  });
+
+  it('should have correct props and layout between loading states', () => {
+    const w1 = { width: 240, height: 100, marginBottom: 10 };
+    const w2 = { width: 180, height: 40 };
+    const layout = [w1, w2];
+    const props: ISkeletonContentProps = {
+      layout,
+      isLoading: true,
+      animationType: 'shiver'
+    };
+    const childStyle = { fontSize: 24 };
+    const instance = create(
+      <PureSkeletonContent
+        {...props}
+        component={Greetings}
+        componentProps={{ name: 'one', style: childStyle }}
+      />
+    );
+    const component = instance.root;
+    let bones = component.findAllByType(LinearGradient);
+    // one animated view child for each bone + parent
+    expect(bones.length).toEqual(layout.length);
+    bones = component.findAllByType(Animated.View);
+    expect(bones[1].props.style).toEqual({
+      ...staticStyles,
+      ...w1
+    });
+    expect(bones[3].props.style).toEqual({
+      ...staticStyles,
+      ...w2
+    });
+    let children = component.findAllByType(Text);
+    // no child since it's loading
+    expect(children.length).toEqual(0);
+
+    // update props
+    instance.update(
+      <PureSkeletonContent
+        {...props}
+        isLoading={false}
+        component={Greetings}
+        componentProps={{ name: 'one', style: childStyle }}
+      />
+    );
+
+    bones = instance.root.findAllByType(LinearGradient);
+    expect(bones.length).toEqual(0);
+
+    children = instance.root.findAllByType(Text);
+    expect(children.length).toEqual(1);
+    expect(children[0].props.style).toEqual(childStyle);
+
+    // re-update to loading state
+    instance.update(
+      <PureSkeletonContent
+        {...props}
+        component={Greetings}
+        componentProps={{ name: 'one', style: childStyle }}
+      />
+    );
+
+    bones = instance.root.findAllByType(LinearGradient);
+    expect(bones.length).toEqual(layout.length);
+    bones = component.findAllByType(Animated.View);
+    expect(bones[1].props.style).toEqual({
+      ...staticStyles,
+      ...w1
+    });
+    expect(bones[3].props.style).toEqual({
+      ...staticStyles,
+      ...w2
+    });
+    children = instance.root.findAllByType(Text);
+    // no child since it's loading
+    expect(children.length).toEqual(0);
+
+    // snapshot
+    expect(instance.toJSON()).toMatchSnapshot();
+  });
+});

--- a/src/__tests__/SkeletonContent.test.tsx
+++ b/src/__tests__/SkeletonContent.test.tsx
@@ -111,21 +111,22 @@ describe('SkeletonComponent test suite', () => {
         ...w1,
         borderRadius: DEFAULT_BORDER_RADIUS
       },
-      { backgroundColor: { ' __value': NaN } }
+      // this value keeps recurring as the interpolated value
+      { backgroundColor: new Animated.Value(4278190080) }
     ]);
     expect(bones[2].props.style).toEqual([
       {
         ...w2,
         borderRadius: DEFAULT_BORDER_RADIUS
       },
-      { backgroundColor: { ' __value': NaN } }
+      { backgroundColor: new Animated.Value(4278190080) }
     ]);
     expect(bones[3].props.style).toEqual([
       {
         ...w3,
         borderRadius: DEFAULT_BORDER_RADIUS
       },
-      { backgroundColor: { ' __value': NaN } }
+      { backgroundColor: new Animated.Value(4278190080) }
     ]);
     expect(instance.toJSON()).toMatchSnapshot();
   });

--- a/src/__tests__/__snapshots__/PureSkeletonContent.test.tsx.snap
+++ b/src/__tests__/__snapshots__/PureSkeletonContent.test.tsx.snap
@@ -1,0 +1,270 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PureSkeletonContent test suite should have correct props and layout between loading states 1`] = `
+<View
+  onLayout={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "flex": 1,
+      "justifyContent": "center",
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "backgroundColor": "#E1E9EE",
+        "borderRadius": 4,
+        "height": 100,
+        "marginBottom": 10,
+        "overflow": "hidden",
+        "width": 240,
+      }
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "height": "100%",
+            "position": "absolute",
+            "width": "100%",
+          },
+          Object {
+            "transform": Array [
+              Object {
+                "translateX": undefined,
+              },
+            ],
+          },
+        ]
+      }
+    >
+      <BVLinearGradient
+        colors={
+          Array [
+            4292995566,
+            4294113532,
+            4292995566,
+          ]
+        }
+        endPoint={
+          Object {
+            "x": 1,
+            "y": 0,
+          }
+        }
+        locations={null}
+        startPoint={
+          Object {
+            "x": 0,
+            "y": 0,
+          }
+        }
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      />
+    </View>
+  </View>
+  <View
+    style={
+      Object {
+        "backgroundColor": "#E1E9EE",
+        "borderRadius": 4,
+        "height": 40,
+        "overflow": "hidden",
+        "width": 180,
+      }
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "height": "100%",
+            "position": "absolute",
+            "width": "100%",
+          },
+          Object {
+            "transform": Array [
+              Object {
+                "translateX": undefined,
+              },
+            ],
+          },
+        ]
+      }
+    >
+      <BVLinearGradient
+        colors={
+          Array [
+            4292995566,
+            4294113532,
+            4292995566,
+          ]
+        }
+        endPoint={
+          Object {
+            "x": 1,
+            "y": 0,
+          }
+        }
+        locations={null}
+        startPoint={
+          Object {
+            "x": 0,
+            "y": 0,
+          }
+        }
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      />
+    </View>
+  </View>
+</View>
+`;
+
+exports[`PureSkeletonContent test suite should have the correct layout when loading 1`] = `
+<View
+  onLayout={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "flex": 1,
+      "justifyContent": "center",
+    }
+  }
+>
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "#E1E9EE",
+          "borderRadius": 4,
+          "height": 100,
+          "marginBottom": 10,
+          "overflow": "hidden",
+          "width": 240,
+        },
+      ]
+    }
+  />
+  <View
+    style={
+      Array [
+        Object {
+          "backgroundColor": "grey",
+          "borderRadius": 20,
+          "height": 40,
+          "overflow": "hidden",
+          "width": 180,
+        },
+      ]
+    }
+  />
+</View>
+`;
+
+exports[`PureSkeletonContent test suite should not re-render PureSkeleton on top component and same props re-render 1`] = `
+<View
+  onLayout={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "flex": 1,
+      "justifyContent": "center",
+    }
+  }
+>
+  <Text>
+    Local: 
+    0
+     Props: 
+    0
+  </Text>
+</View>
+`;
+
+exports[`PureSkeletonContent test suite should not re-render PureSkeleton on top component and same props re-render 2`] = `
+<View
+  onLayout={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "flex": 1,
+      "justifyContent": "center",
+    }
+  }
+>
+  <Text>
+    Local: 
+    1
+     Props: 
+    1
+  </Text>
+</View>
+`;
+
+exports[`PureSkeletonContent test suite should not re-render PureSkeleton on top component and same props re-render 3`] = `
+<View
+  onLayout={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "flex": 1,
+      "justifyContent": "center",
+    }
+  }
+>
+  <Text>
+    Local: 
+    1
+     Props: 
+    1
+  </Text>
+</View>
+`;
+
+exports[`PureSkeletonContent test suite should not re-render PureSkeleton on top component and same props re-render 4`] = `
+<View
+  onLayout={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "flex": 1,
+      "justifyContent": "center",
+    }
+  }
+>
+  <Text>
+    Local: 
+    2
+     Props: 
+  </Text>
+</View>
+`;
+
+exports[`PureSkeletonContent test suite should render empty alone 1`] = `
+<View
+  onLayout={[Function]}
+  style={
+    Object {
+      "alignItems": "center",
+      "flex": 1,
+      "justifyContent": "center",
+    }
+  }
+>
+  <Text>
+    Hello 
+    World
+  </Text>
+</View>
+`;

--- a/src/__tests__/__snapshots__/SkeletonContent.test.tsx.snap
+++ b/src/__tests__/__snapshots__/SkeletonContent.test.tsx.snap
@@ -206,7 +206,7 @@ exports[`SkeletonComponent test suite should render the correct bones for childr
         },
         Object {
           "backgroundColor": AnimatedValue {
-            " __value": NaN,
+            " __value": 4278190080,
           },
         },
       ]
@@ -222,7 +222,7 @@ exports[`SkeletonComponent test suite should render the correct bones for childr
         },
         Object {
           "backgroundColor": AnimatedValue {
-            " __value": NaN,
+            " __value": 4278190080,
           },
         },
       ]
@@ -238,7 +238,7 @@ exports[`SkeletonComponent test suite should render the correct bones for childr
         },
         Object {
           "backgroundColor": AnimatedValue {
-            " __value": NaN,
+            " __value": 4278190080,
           },
         },
       ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,7 @@
+import { FunctionComponent } from 'react';
 import SkeletonContent from './SkeletonContent';
+import PureSkeletonContent from './PureSkeletonContent';
+import { ISkeletonContentProps } from './Constants';
 
-export default SkeletonContent;
+export { PureSkeletonContent };
+export default SkeletonContent as FunctionComponent<ISkeletonContentProps>;


### PR DESCRIPTION
This is a proof of concept as well as a final code to support this issue #28 i opened earlier. 

As a guide, this section has been added to the README file.

## PureSkeletonContent
If you are really concerned about performance, or you don't want your components mounting being runned while
`isLoading` **is false**, then you may need to consider using `PureSkeletonContent`.

#### Point to note 
All props passed to PureSkeletonContent should be a **constant** prop, **memoize** it if it will change sometime.
Otherwise, you should consider using the good old `SkeletonContent`.
**This point does not apply to componentProps as it is shallow checked to know if we should re-render the Skeleton or not.*


```typescript jsx
import { FunctionComponent } from 'react';
import { Text, TextStyle, StyleSheet } from 'react-native';
import { PureSkeletonContent } from 'react-native-skeleton-content-nonexpo'; 

const Greetings: FunctionComponent<{ name: string }> = ({ name }) => 
  (<Text>Hello {name}</Text>);

const GreetingsSC = [{ height: 40, width: 200, paddingVertical: 2 }];

const SomeComponent: FunctionComponent<{name: string}> = ({ name }) => {
  const [loading, setLoading] = useState(true);

  return (
    <PureSkeletonContent 
      isLoading={isLoading}
      layout={GreetingsSC}
      component={Greetings} 
      componentProps={{ name }} // will be shallow checked, you don't need to memoize this
      containerStyle={styles.container} // notice we using styles from styleSheet
    />
  )
}

const styles = StyleSheet({
  container: {
    flex: 1, width: 300
  }
})
```
