### PR TITLE
Support react-native-reanimated v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5431,6 +5431,23 @@
         }
       }
     },
+    "cross-fetch": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "2.6.1"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+          "dev": true
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -10072,6 +10089,12 @@
         "minimist": "^1.2.5"
       }
     },
+    "mockdate": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-3.0.5.tgz",
+      "integrity": "sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==",
+      "dev": true
+    },
     "morgan": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
@@ -10200,9 +10223,9 @@
       }
     },
     "normalize-svg-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.0.1.tgz",
-      "integrity": "sha1-b3Ka1rcLtMpO/y/ksQdInv4dVv4=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
+      "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
       "requires": {
         "svg-arc-to-cubic-bezier": "^3.0.0"
       }
@@ -11391,18 +11414,53 @@
       "dev": true
     },
     "react-native-reanimated": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-1.9.0.tgz",
-      "integrity": "sha512-Aj+spgIHRiVv7ezGADxnSH1EoKrQRD2+XaSiGY0MiB/pvRNNrZPSJ+3NVpvLwWf9lZMOP7dwqqyJIzoZgBDt8w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.0.0.tgz",
+      "integrity": "sha512-kIrdBoXSky7DQ62SOgosgimKM+Lt+SzAaM+ovVpCLBcwUK2aYRfLxa9ffgvKjeH9/n7dONlwEMjbKssGkuyq2Q==",
       "dev": true,
       "requires": {
-        "fbjs": "^1.0.0"
+        "@babel/plugin-transform-object-assign": "^7.10.4",
+        "fbjs": "^3.0.0",
+        "mockdate": "^3.0.2",
+        "string-hash-64": "^1.0.3"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.13.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+          "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
+          "dev": true
+        },
+        "@babel/plugin-transform-object-assign": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.12.13.tgz",
+          "integrity": "sha512-4QxDMc0lAOkIBSfCrnSGbAJ+4epDBF2XXwcLXuBcG1xl9u7LrktNVD4+LwhL47XuKVPQ7R25e/WdcV+h97HyZA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.12.13"
+          }
+        },
+        "fbjs": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.0.tgz",
+          "integrity": "sha512-dJd4PiDOFuhe7vk4F80Mba83Vr2QuK86FoxtgPmzBqEJahncp+13YCmfoa53KHCo6OnlXLG7eeMWPfB5CrpVKg==",
+          "dev": true,
+          "requires": {
+            "cross-fetch": "^3.0.4",
+            "fbjs-css-vars": "^1.0.0",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
+          }
+        }
       }
     },
     "react-native-redash": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/react-native-redash/-/react-native-redash-14.1.1.tgz",
-      "integrity": "sha512-xjTmEEnDKXa7DlGhKpL7HUksSGS6RFY8duig1YWrADnatTKBiwRBTymLJplqs9jE9rSOEeqISRYhtkB9iRlfRA==",
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/react-native-redash/-/react-native-redash-14.2.4.tgz",
+      "integrity": "sha512-/1R9UxXv3ffKcrbxolqa2B247Cgd3ikyEm2q1VlBng77Es6PAD4LAOXQ83pBavvwNfOsbhF3ebkbMpJcLaVt3Q==",
       "requires": {
         "abs-svg-path": "^0.1.1",
         "normalize-svg-path": "^1.0.1",
@@ -12301,6 +12359,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
       "integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ=",
+      "dev": true
+    },
+    "string-hash-64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string-hash-64/-/string-hash-64-1.0.3.tgz",
+      "integrity": "sha512-D5OKWKvDhyVWWn2x5Y9b+37NUllks34q1dCDhk/vYcso9fmhs+Tl3KR/gE4v5UNj2UA35cnX4KdVVGkG1deKqw==",
       "dev": true
     },
     "string-length": {

--- a/package.json
+++ b/package.json
@@ -54,11 +54,11 @@
   },
   "homepage": "https://github.com/alexZajac/react-native-skeleton-content-nonexpo#readme",
   "dependencies": {
-    "react-native-redash": "^14.0.0"
+    "react-native-redash": "^14.2.4"
   },
   "peerDependencies": {
     "react-native-linear-gradient": "^2.5.1",
-    "react-native-reanimated": "^1.5.0"
+    "react-native-reanimated": "^2.0.0"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.10.1",
@@ -77,7 +77,7 @@
     "react-native": "^0.61.2",
     "react-native-gesture-handler": "^1.7.0",
     "react-native-linear-gradient": "^2.5.6",
-    "react-native-reanimated": "^1.9.0",
+    "react-native-reanimated": "^2.0.0",
     "react-test-renderer": "^16.13.1",
     "typescript": "^3.7.2"
   },

--- a/src/SkeletonContent.tsx
+++ b/src/SkeletonContent.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { StyleSheet, View } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
-import Animated, { interpolate } from 'react-native-reanimated';
+import Animated, { interpolateNode } from 'react-native-reanimated';
 import { interpolateColor, loop, useValue } from 'react-native-redash';
 import {
   ICustomViewStyle,
@@ -222,7 +222,7 @@ const SkeletonContent: React.FunctionComponent<ISkeletonContentProps> = ({
       animationDirection === 'horizontalLeft' ||
       animationDirection === 'horizontalRight'
     ) {
-      const interpolatedPosition = interpolate(animationValue, {
+      const interpolatedPosition = interpolateNode(animationValue, {
         inputRange: [0, 1],
         outputRange: getPositionRange(boneLayout)
       });
@@ -290,11 +290,11 @@ const SkeletonContent: React.FunctionComponent<ISkeletonContentProps> = ({
           yOutputRange.reverse();
         }
       }
-      let translateX = interpolate(animationValue, {
+      let translateX = interpolateNode(animationValue, {
         inputRange: [0, 1],
         outputRange: xOutputRange
       });
-      let translateY = interpolate(animationValue, {
+      let translateY = interpolateNode(animationValue, {
         inputRange: [0, 1],
         outputRange: yOutputRange
       });


### PR DESCRIPTION
### Description of the Change

Update `react-native-reanimated` from v1 to v2 now that there's a stable release. For the scope of this library, the are no major breaking changes other than the first point mentioned in the official `react-native-reanimated` [docs on how to migrate from v1 to v2](https://docs.swmansion.com/react-native-reanimated/docs/migration). In this case, it's only about renaming the method `interpolate` to `interpolateNode`.